### PR TITLE
feat: build cosmwasm contract from contract repo as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
-[submodule "contrib/images/ibcsim-wasmd/babylon-contract"]
-path = contrib/images/ibcsim-wasmd/babylon-contract
+[submodule "babylon-contract"]
+path = babylon-contract
 url = git@github.com:babylonlabs-io/babylon-contract.git
 [submodule "covenant-emulator"]
 path = covenant-emulator

--- a/contrib/images/Makefile
+++ b/contrib/images/Makefile
@@ -5,18 +5,11 @@ else
 	BITCOINDSIM_TAG := $(BITCOIN_CORE_VERSION)
 endif
 
-all: bitcoinsim ibcsim-wasmd
+all: bitcoinsim
 
 bitcoindsim:
 	docker build --platform "linux/amd64" --tag babylonlabs-io/bitcoindsim:$(BITCOINDSIM_TAG) -f bitcoindsim/Dockerfile \
 		$(shell git rev-parse --show-toplevel)/contrib/images/bitcoindsim $(BITCOINDSIM_BUILD_ARG)
-
-ibcsim-wasmd:
-	cd ibcsim-wasmd/babylon-contract && \
-	cargo install cargo-run-script && \
-	cargo clean && \
-	cargo build && \
-	cargo run-script optimize 2>/dev/null; true
 
 ibcsim-gaia:
 	docker build --tag babylonlabs-io/ibcsim-gaia -f ibcsim-gaia/Dockerfile \
@@ -26,9 +19,6 @@ ibcsim-bcd:
 	docker build --secret id=sshKey,src=${BBN_PRIV_DEPLOY_KEY} \
 		--tag babylonlabs-io/ibcsim-bcd -f ibcsim-bcd/Dockerfile \
 		$(shell git rev-parse --show-toplevel)/contrib/images/ibcsim-bcd
-
-ibcsim-wasmd-clean:
-	cd ibcsim-wasmd/babylon-contract && rm -rf artifacts 2>/dev/null; true
 
 btcdsim-rmi:
 	docker rmi babylonlabs-io/btcdsim 2>/dev/null; true
@@ -42,4 +32,4 @@ ibcsim-gaia-rmi:
 ibcsim-bcd-rmi:
 	docker rmi babylonlabs-io/ibcsim-bcd 2>/dev/null; true
 
-.PHONY: all btcdsim ibcsim-wasmd ibcsim-wasmd-clean btcdsim-rmi bitcoindsim bitcoindsim-rmi ibcsim-gaia ibcsim-gaia-rmi ibcsim-bcd ibcsim-bcd-rmi
+.PHONY: all btcdsim btcdsim-rmi bitcoindsim bitcoindsim-rmi ibcsim-gaia ibcsim-gaia-rmi ibcsim-bcd ibcsim-bcd-rmi

--- a/deployments/finality-gadget-integration-op-l2/Makefile
+++ b/deployments/finality-gadget-integration-op-l2/Makefile
@@ -8,10 +8,6 @@ export
 DOCKER := $(shell which docker)
 GIT_TOPLEVEL := $(shell git rev-parse --show-toplevel)
 
-build-babylon-contract:
-	@$(MAKE) -C $(GIT_TOPLEVEL)/contrib/images ibcsim-wasmd
-	@cp $(GIT_TOPLEVEL)/contrib/images/ibcsim-wasmd/babylon-contract/artifacts/op_finality_gadget.wasm $(GIT_TOPLEVEL)/deployments/finality-gadget-integration-op-l2/artifacts
-
 build-bitcoindsim:
 	@$(MAKE) -C $(GIT_TOPLEVEL)/contrib/images bitcoindsim
 
@@ -34,7 +30,6 @@ build-finality-gadget:
 	@$(MAKE) -C $(GIT_TOPLEVEL)/finality-gadget build-docker
 
 build: build-babylond \
-	build-babylon-contract \
 	build-bitcoindsim \
 	build-vigilante \
 	build-btc-staker-phase-3 \

--- a/deployments/finality-gadget-integration-op-l2/deploy-cw-contract.sh
+++ b/deployments/finality-gadget-integration-op-l2/deploy-cw-contract.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+### generate CW contract
+OLD_PWD=$(pwd)
+GIT_TOPLEVEL=$(git rev-parse --show-toplevel)
+cd $GIT_TOPLEVEL/babylon-contract
+cargo install cargo-run-script
+cargo clean
+cargo build
+sleep 1
+cargo run-script optimize 2>/dev/null
+cp ./artifacts/op_finality_gadget.wasm $GIT_TOPLEVEL/deployments/finality-gadget-integration-op-l2/artifacts
+cd $OLD_PWD
 ### Store the CW contract code
 # Copy the wasm file into the container
 echo "wasm file: $WASM_FILE_LOCAL, $WASM_FILE_CONTAINER"


### PR DESCRIPTION
# Summary
Modified makefile to build cosmwasm contract from babylon-contract repo as a submodule.

# Test Plan
```
cd deployments/finality-gadget-integration-op-l2
make start 
```
or 
```
make build-babylon-contract
```