### PR TITLE
feat: add a CI workflow to publish the bitcoinsim image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+name: docker_publish
+
+on:
+  push:
+    paths:
+      - 'contrib/images/bitcoindsim/**'
+
+jobs:
+  docker_pipeline:
+    needs: []
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
+    secrets: inherit
+    with:
+      publish: true
+      dockerfile: ./contrib/images/bitcoindsim/Dockerfile
+      repoName: bitcoindsim

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,4 +13,5 @@ jobs:
     with:
       publish: true
       dockerfile: ./contrib/images/bitcoindsim/Dockerfile
+      dockerContext: ./contrib/images/bitcoindsim
       repoName: bitcoindsim

--- a/contrib/images/bitcoindsim/wrapper.sh
+++ b/contrib/images/bitcoindsim/wrapper.sh
@@ -12,7 +12,7 @@ if [[ -z "$BITCOIN_RPC_PORT" ]]; then
   BITCOIN_RPC_PORT="18443"
 fi
 
-if [[ "$BITCOIN_NETWORK" != "regtest" && "$BITCOIN_NETWORK" != "signet" && "$BITCOIN_NETWORK" != "testnet" ]]; then
+if [[ "$BITCOIN_NETWORK" != "regtest" && "$BITCOIN_NETWORK" != "signet" ]]; then
   echo "Unsupported network: $BITCOIN_NETWORK"
   exit 1
 fi
@@ -22,11 +22,7 @@ if [[ ! -d "$BITCOIN_DATA" ]]; then
   mkdir -p "$BITCOIN_DATA"
 fi
 echo "Generating bitcoin.conf file at $BITCOIN_CONF"
-if [[ "$BITCOIN_NETWORK" == "testnet" ]]; then
-  NETWORK_LABEL="test" # [test] not [testnet] for testnet3
-else
-  NETWORK_LABEL="$BITCOIN_NETWORK"
-fi
+NETWORK_LABEL="$BITCOIN_NETWORK"
 cat <<EOF > "$BITCOIN_CONF"
 # Enable ${BITCOIN_NETWORK} mode.
 ${BITCOIN_NETWORK}=1
@@ -110,7 +106,7 @@ if [[ "$BITCOIN_NETWORK" == "regtest" ]]; then
     fi
     sleep "${GENERATE_INTERVAL_SECS}"
   done
-elif [[ "$BITCOIN_NETWORK" == "signet" || "$BITCOIN_NETWORK" == "testnet" ]]; then
+elif [[ "$BITCOIN_NETWORK" == "signet" ]]; then
   # Check if the wallet database already exists.
   if [[ -d "$BITCOIN_DATA"/${BITCOIN_NETWORK}/wallets/"$BTCSTAKER_WALLET_NAME" ]]; then
     echo "Wallet already exists, loading it: $BITCOIN_DATA/${BITCOIN_NETWORK}/wallets/$BTCSTAKER_WALLET_NAME"

--- a/contrib/images/bitcoindsim/wrapper.sh
+++ b/contrib/images/bitcoindsim/wrapper.sh
@@ -23,7 +23,7 @@ if [[ ! -d "$BITCOIN_DATA" ]]; then
 fi
 echo "Generating bitcoin.conf file at $BITCOIN_CONF"
 if [[ "$BITCOIN_NETWORK" == "testnet" ]]; then
-  NETWORK_LABEL="test"
+  NETWORK_LABEL="test" # Testnet3
 else
   NETWORK_LABEL="$BITCOIN_NETWORK"
 fi

--- a/contrib/images/bitcoindsim/wrapper.sh
+++ b/contrib/images/bitcoindsim/wrapper.sh
@@ -23,7 +23,7 @@ if [[ ! -d "$BITCOIN_DATA" ]]; then
 fi
 echo "Generating bitcoin.conf file at $BITCOIN_CONF"
 if [[ "$BITCOIN_NETWORK" == "testnet" ]]; then
-  NETWORK_LABEL="test" # Testnet3
+  NETWORK_LABEL="test" # [test] not [testnet] for testnet3
 else
   NETWORK_LABEL="$BITCOIN_NETWORK"
 fi

--- a/deployments/finality-gadget-integration-op-l2/Makefile
+++ b/deployments/finality-gadget-integration-op-l2/Makefile
@@ -187,7 +187,7 @@ start-babylon:
 	else \
 		echo "Unsupported bitcoin network: $(BITCOIN_NETWORK)"; \
 	fi
-.PHONY: start
+.PHONY: start-babylon
 
 stop-babylon:
 	@$(DOCKER) compose -f artifacts/docker-compose.yml down -v
@@ -204,7 +204,7 @@ stop-babylon:
 	else \
 		echo "Unsupported bitcoin network: $(BITCOIN_NETWORK)"; \
 	fi
-.PHONY: stop
+.PHONY: stop-babylon
 
 # Run independent steps 
 # TODO: remove these after testing


### PR DESCRIPTION
## Summary

This PR adds a CI workflow that publishes the `bitcoinsim` docker image when changes are made to the `contrib/images/bitcoindsim/` directory.

## Test Plan

Update the `Dockerfile` or `wrapper.sh` and then `bitcoindsim` image should be published to the Babylon docker hub.
