### PR TITLE
fix: incompatible covenant-emulator version

### DIFF
--- a/deployments/finality-gadget-integration-op-l2/artifacts/docker-compose.yml
+++ b/deployments/finality-gadget-integration-op-l2/artifacts/docker-compose.yml
@@ -187,7 +187,7 @@ services:
 
   covenant-emulator:
     container_name: covenant-emulator
-    image: babylonlabs/covenant-emulator:v0.5.0
+    image: babylonlabs/covenant-emulator:v0.4.0
     command: covd start
     networks:
       localnet:


### PR DESCRIPTION
## Summary

v0.5.0 uses babylon v0.13.0 which includes https://github.com/babylonlabs-io/babylon/pull/197 that adds a new field so all other fields shift by 1

leading to covenant-emulator logs:

```
2024-10-19T02:27:12.239042Z	debug	failed to get pending delegations	{"error": "failed to query BTC delegations: proto: wrong wireType = 2 for field TotalSat"}
```

reverting to 0.4.0 should fix it b/c it uses v0.12.0 babylon that doesn't include this PR

https://github.com/babylonlabs-io/covenant-emulator/blob/v0.4.0/go.mod#L11

## Test Plan

rerun the cmd