### PR TITLE
fix: deploy error for integration-op-l2

### DIFF
--- a/deployments/finality-gadget-integration-op-l2/Makefile
+++ b/deployments/finality-gadget-integration-op-l2/Makefile
@@ -17,11 +17,11 @@ build-babylond:
 build-vigilante:
 	@$(MAKE) -C $(GIT_TOPLEVEL)/vigilante build-docker
 
-build-btc-staker-phase-3:
-	@$(MAKE) -C $(GIT_TOPLEVEL)/btc-staker-phase-3 build-docker
+build-btc-staker:
+	@$(MAKE) -C $(GIT_TOPLEVEL)/btc-staker build-docker
 
-build-finality-provider-phase-3:
-	@$(MAKE) -C $(GIT_TOPLEVEL)/finality-provider-phase-3 build-docker
+build-finality-provider:
+	@$(MAKE) -C $(GIT_TOPLEVEL)/finality-provider build-docker
 
 build-covenant-emulator:
 	@$(MAKE) -C $(GIT_TOPLEVEL)/covenant-emulator build-docker
@@ -35,8 +35,8 @@ build-cw-contract:
 build: build-babylond \
 	build-bitcoindsim \
 	build-vigilante \
-	build-btc-staker-phase-3 \
-	build-finality-provider-phase-3 \
+	build-btc-staker \
+	build-finality-provider \
 	build-finality-gadget \
 	build-covenant-emulator \
 	build-cw-contract

--- a/deployments/finality-gadget-integration-op-l2/init-testnets-dir.sh
+++ b/deployments/finality-gadget-integration-op-l2/init-testnets-dir.sh
@@ -56,7 +56,7 @@ docker run --rm -v $(pwd)/.testnets:/data babylonlabs-io/babylond \
     --btc-base-header-height $BASE_HEADER_HEIGHT \
     --btc-network $BITCOIN_NETWORK \
     --additional-sender-account \
-    --slashing-address $SLASHING_ADDRESS \
+    --slashing-pk-script "76a914010101010101010101010101010101010101010188ab" \
     --slashing-rate 0.1 \
     --min-commission-rate 0.05 \
     --covenant-quorum 1 \


### PR DESCRIPTION
Hi, I ran into some problems when trying to test `finality-gadget-integration-op-l2` and tried to make fixes including
1. Updating `babylon-contract` submodule to fix a compilation issue with [`contracts/babylon/src/contract.rs`](https://github.com/babylonlabs-io/babylon-contract/commit/a7cd0588be64b17cb080b3f4117a3c38a4827ea6)
2. Updating Makefile submodule paths
3. Fix `slashing-address` flag not existing error and change it to `slashing-pk-script`