### PR TITLE
[R4R]add -deprecatedrpc=warnings in wrapper.sh for bitcoin start command

### DIFF
--- a/contrib/images/bitcoindsim/wrapper.sh
+++ b/contrib/images/bitcoindsim/wrapper.sh
@@ -51,7 +51,7 @@ rpcallowip=0.0.0.0/0
 EOF
 
 echo "Starting bitcoind..."
-bitcoind -${BITCOIN_NETWORK} -datadir="$BITCOIN_DATA" -conf="$BITCOIN_CONF" -daemon
+bitcoind -${BITCOIN_NETWORK} -datadir="$BITCOIN_DATA" -conf="$BITCOIN_CONF" -deprecatedrpc=warnings -daemon
 # Allow some time for bitcoind to start
 sleep 3
 


### PR DESCRIPTION
Compatible with different versions of bitcoin core。

In Bitcoin Core version 28.0, the warnings field for RPC commands such as getnetworkinfo, getblockchaininfo, and getmininginfo was changed from a single string to an array of strings. ￼

If you need to restore the old behavior, you can add the -deprecatedrpc=warnings configuration option when starting Bitcoin Core.

Note that support for the old behavior may be removed in future versions, and it is recommended to update applications that rely on this field to adapt to the new data format.