### PR TITLE
[R4R]: vigilante.yml is wrong, should change database-config to dbconfig

### DIFF
--- a/deployments/btc-staking-integration-bitcoind/artifacts/vigilante.yml
+++ b/deployments/btc-staking-integration-bitcoind/artifacts/vigilante.yml
@@ -58,7 +58,7 @@ submitter:
   polling-interval-seconds: 60
   resend-interval-seconds: 1800
   resubmit-fee-multiplier: 2
-  database-config:
+  dbconfig:
     dbpath: /home/vigilante/db
     dbfilename: vigilante.db
     nofreelistsync: false
@@ -79,7 +79,7 @@ monitor:
   enable-liveness-checker: true
   enable-slasher: true
   btcnetparams: regtest
-  database-config:
+  dbconfig:
     dbpath: /home/vigilante/db
     dbfilename: vigilante.db
     nofreelistsync: false


### PR DESCRIPTION
```
type SubmitterConfig struct {
	// NetParams defines the BTC network params, which should be mainnet|testnet|simnet|signet
	NetParams string `mapstructure:"netparams"`
	// BufferSize defines the number of raw checkpoints stored in the buffer
	BufferSize uint `mapstructure:"buffer-size"`
	// ResubmitFeeMultiplier is used to multiply the estimated bumped fee in resubmission
	ResubmitFeeMultiplier float64 `mapstructure:"resubmit-fee-multiplier"`
	// PollingIntervalSeconds defines the intervals (in seconds) between each polling of Babylon checkpoints
	PollingIntervalSeconds int64 `mapstructure:"polling-interval-seconds"`
	// ResendIntervalSeconds defines the time (in seconds) which the submitter awaits
	// before resubmitting checkpoints to BTC
	ResendIntervalSeconds uint `mapstructure:"resend-interval-seconds"`
	// DatabaseConfig stores last submitted txn
	DatabaseConfig *DBConfig `mapstructure:"dbconfig"`
}
```
DatabaseConfig's mapstructure is dbconfig, not database-config, So change vigilante.yml database-config to dbconfig, If you don't do this, vigilante will panic because it can't get the configuration value.