### PR TITLE
fix(git-mod): add missing records on gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,9 @@
 [submodule "btc-staker"]
 	path = btc-staker
 	url = git@github.com:babylonlabs-io/btc-staker.git
+[submodule "optimism"]
+	path = optimism
+	url = git@github.com:babylonlabs-io/optimism.git
+[submodule "finality-gadget"]
+	path = finality-gadget
+	url = git@github.com:babylonlabs-io/finality-gadget.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,3 @@
 [submodule "btc-staker"]
 	path = btc-staker
 	url = git@github.com:babylonlabs-io/btc-staker.git
-[submodule "optimism"]
-	path = optimism
-	url = git@github.com:babylonlabs-io/optimism.git
-[submodule "finality-gadget"]
-	path = finality-gadget
-	url = git@github.com:babylonlabs-io/finality-gadget.git


### PR DESCRIPTION
# Description

When following the [README instructions on the btc-staking-integration-bitcoind](https://github.com/babylonlabs-io/babylon-integration-deployment/tree/main/deployments/btc-staking-integration-bitcoind), I'm getting the following error on running the `git submodule update --init` command due to some records missing on the `.gitmodules`

```
❯ git submodule update --init
fatal: No url found for submodule path 'finality-gadget' in .gitmodules
```

## Expected

Should clone the corresponding modules

## Fix

This PR introduces the changes to add the missing records (`optimism` and `finality-gadget`) on the `.gitmodules`.
An alternative solution is removing the corresponding directories if these are unused.